### PR TITLE
twbs-input-number 1.1.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
+
+
 [1]: https://github.com/IonicaBizau/twbs-input-number/issues
 
 [2]: https://github.com/IonicaBizau/code-style

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,15 @@
+## Documentation
+
+You can see below the API reference of this module.
+
+### `twbsNumberInput(options)`
+Initializes the twbs number input.
+
+#### Params
+- **Object** `options`: An object containing:
+ - `selector` (String): If provided, the selected elements will be overridden.
+ - `check` (Boolean): Check the values after init (default: `true`).
+
+#### Return
+- **jQuery** The selected elements.
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+
 # Twitter Bootstrap - Input number [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/twbs-input-number.svg)](https://www.npmjs.com/package/twbs-input-number) [![Downloads](https://img.shields.io/npm/dt/twbs-input-number.svg)](https://www.npmjs.com/package/twbs-input-number) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > jQuery plugin for input number for Twitter Boostrap: compatible with IE10
+
 
 Currently only TWBS 2.x.x is supported.
 
@@ -22,13 +24,16 @@ $(document).on("ready", function () {
 
 [DEMO](http://jsfiddle.net/AgxmX/5/)
 
-## Installation
+
+## :cloud: Installation
 
 ```sh
 $ npm i --save twbs-input-number
 ```
 
-## Documentation
+
+## :memo: Documentation
+
 
 ### `twbsNumberInput(options)`
 Initializes the twbs number input.
@@ -41,13 +46,13 @@ Initializes the twbs number input.
 #### Return
 - **jQuery** The selected elements.
 
-## How to contribute
+
+
+## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
-## Where is this library used?
-If you are using this library in one of your projects, add it in this list. :sparkles:
 
-## License
+## :scroll: License
 
 [MIT][license] © [Ionică Bizău][website]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twbs-input-number",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "jQuery plugin for input number for Twitter Boostrap: compatible with IE10",
   "main": "lib/index.js",
   "scripts": {
@@ -56,5 +56,16 @@
         "p": "[DEMO](http://jsfiddle.net/AgxmX/5/)"
       }
     ]
-  }
+  },
+  "files": [
+    "bin/",
+    "app/",
+    "lib/",
+    "dist/",
+    "src/",
+    "resources/",
+    "menu/",
+    "cli.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.